### PR TITLE
Permission management

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,16 +3,16 @@
 
  This plugin allows confguring and running SonarQube analysis in the TeamCity server.
 
- 1. Downloading binaries 
+ 1. Downloading binaries
  =====
 
- The latest build of the plugin is available on public TeamCity server and could be downloaded from: 
+ The latest build of the plugin is available on public TeamCity server and could be downloaded from:
  http://teamcity.jetbrains.com/repository/download/TeamCityPluginsByJetBrains_TeamCitySonarQubePlugin_Build/.lastPinned/sonar-plugin.zip
 
  2. Building sources
  =====
 
- Run the following command in the root of checked out repository: 
+ Run the following command in the root of checked out repository:
  mvn clean package
 
  3. Installing
@@ -35,6 +35,8 @@
  b. Configuring SonarQube Server locations to send information from the SonarQube Runner to
 
  Any number of SonarQube Server connections could be defined for a project. A connection could be used in any Build Configuration under the project including those from subprojects.
+
+ The permission 'Edit project' is required to manage SonarQube servers (add/edit/remove, and view account).
 
  c. Build Breaker plugin integration
 

--- a/sonar-plugin-server/src/main/java/jetbrains/buildserver/sonarplugin/sqrunner/ServerManagementProjectTab.java
+++ b/sonar-plugin-server/src/main/java/jetbrains/buildserver/sonarplugin/sqrunner/ServerManagementProjectTab.java
@@ -2,13 +2,18 @@ package jetbrains.buildserver.sonarplugin.sqrunner;
 
 import jetbrains.buildServer.controllers.admin.projects.EditProjectTab;
 import jetbrains.buildServer.serverSide.SProject;
+import jetbrains.buildServer.serverSide.auth.AuthUtil;
+import jetbrains.buildServer.serverSide.auth.Permission;
+import jetbrains.buildServer.serverSide.auth.SecurityContext;
 import jetbrains.buildServer.web.openapi.PagePlaces;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
 import jetbrains.buildserver.sonarplugin.sqrunner.manager.SQSInfo;
 import jetbrains.buildserver.sonarplugin.sqrunner.manager.SQSManager;
+
 import org.jetbrains.annotations.NotNull;
 
 import javax.servlet.http.HttpServletRequest;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,14 +29,18 @@ public class ServerManagementProjectTab extends EditProjectTab {
 
     @NotNull
     private final SQSManager mySqsManager;
+    @NotNull
+    private final SecurityContext securityContext;
 
     private static final String TAB_TITLE = "SonarQube Servers";
 
     public ServerManagementProjectTab(@NotNull final PagePlaces pagePlaces,
                                       @NotNull final PluginDescriptor pluginDescriptor,
-                                      @NotNull final SQSManager sqsManager) {
+                                      @NotNull final SQSManager sqsManager,
+                                      @NotNull final SecurityContext securityContext) {
         super(pagePlaces, pluginDescriptor.getPluginName(), "manageSonarServers.jsp", TAB_TITLE);
         mySqsManager = sqsManager;
+        this.securityContext = securityContext;
         addCssFile(pluginDescriptor.getPluginResourcesPath("manageSonarServers.css"));
         addJsFile(pluginDescriptor.getPluginResourcesPath("manageSonarServers.js"));
     }
@@ -46,9 +55,8 @@ public class ServerManagementProjectTab extends EditProjectTab {
         final List<SQSInfo> availableServers = mySqsManager.getAvailableServers(single(currentProject));
         if (availableServers.isEmpty()) {
             return TAB_TITLE;
-        } else {
-            return TAB_TITLE + " (" + availableServers.size() + ")";
         }
+        return TAB_TITLE + " (" + availableServers.size() + ")";
     }
 
     @Override
@@ -60,6 +68,7 @@ public class ServerManagementProjectTab extends EditProjectTab {
         Map<SProject, List<SQSInfo>> infoMap = getServersMap(currentProject);
         model.put("availableServersMap", infoMap);
         model.put("projectId", currentProject.getExternalId());
+        model.put("userHasPermissionManagement", AuthUtil.hasPermissionToManageProject(securityContext.getAuthorityHolder(), currentProject.getExternalId()));
     }
 
     private Map<SProject, List<SQSInfo>> getServersMap(@NotNull final SProject currentProject) {

--- a/sonar-plugin-server/src/main/resources/buildServerResources/manageSonarServers.jsp
+++ b/sonar-plugin-server/src/main/resources/buildServerResources/manageSonarServers.jsp
@@ -19,9 +19,11 @@
     <h2 class="noBorder">SonarQube Server profiles</h2>
     <div class="grayNote">Profiles to connect to SonarQube Servers</div>
 
-    <div class="add">
-        <forms:addButton id="createNewServer" onclick="SonarPlugin.addServer('${projectId}'); return false">Add new server</forms:addButton>
-    </div>
+    <c:if test="${userHasPermissionManagement}">
+        <div class="add">
+            <forms:addButton id="createNewServer" onclick="SonarPlugin.addServer('${projectId}'); return false">Add new server</forms:addButton>
+        </div>
+    </c:if>
 
     <bs:refreshable containerId="SQservers" pageUrl="${pageUrl}">
         <div class="sqsList">
@@ -32,7 +34,9 @@
                             <th class="id">Name</th>
                             <th class="host">Server</th>
                             <th class="db">Database</th>
-                            <th class="actions" colspan="2">Manage</th>
+                            <c:if test="${userHasPermissionManagement}">
+                                <th class="actions" colspan="2">Manage</th>
+                            </c:if>
                         </tr>
                         <c:forEach items="${availableServersMap}" var="projectServersEntry">
                             <c:forEach items="${projectServersEntry.value}" var="server">
@@ -46,40 +50,46 @@
                                     </td>
                                     <td class="url">
                                         <div class="url"><c:out value="${server.url}"/></div>
-                                        <c:choose>
-                                            <c:when test="${not empty server.login}">
-                                                <div class="login">Username: <c:out value="${server.login}"/></div>
-                                                <div class="password">Password: *****</div>
-                                            </c:when>
-                                            <c:otherwise>
-                                                <div class="authentication grayNote">Anonymous</div>
-                                            </c:otherwise>
-                                        </c:choose>
+                                        <c:if test="${userHasPermissionManagement}">
+                                            <c:choose>
+                                                <c:when test="${not empty server.login}">
+                                                    <div class="login">Username: <c:out value="${server.login}"/></div>
+                                                    <div class="password">Password: *****</div>
+                                                </c:when>
+                                                <c:otherwise>
+                                                    <div class="authentication grayNote">Anonymous</div>
+                                                </c:otherwise>
+                                            </c:choose>
+                                        </c:if>
                                     </td>
                                     <td class="db">
                                         <c:choose>
                                             <c:when test="${not empty server.JDBCUrl}"><div class="url"><c:out value="${server.JDBCUrl}"/></div></c:when>
                                             <c:otherwise><div class="defaultValue grayNote">jdbc:h2:tcp://localhost:9092/sonar</div></c:otherwise>
                                         </c:choose>
-                                        <c:choose>
-                                            <c:when test="${not empty server.JDBCUsername}"><div class="dbUser">Username: <c:out value="${server.JDBCUsername}"/></div></c:when>
-                                            <c:otherwise><div class="defaultValue grayNote">Username: sonar</div></c:otherwise>
-                                        </c:choose>
-                                        <c:choose>
-                                            <c:when test="${not empty server.JDBCPassword}"><div class="dbPass">Password: *****</div></c:when>
-                                            <c:otherwise><div class="defaultValue grayNote">Password: sonar</div></c:otherwise>
-                                        </c:choose>
+                                        <c:if test="${userHasPermissionManagement}">
+                                            <c:choose>
+                                                <c:when test="${not empty server.JDBCUsername}"><div class="dbUser">Username: <c:out value="${server.JDBCUsername}"/></div></c:when>
+                                                <c:otherwise><div class="defaultValue grayNote">Username: sonar</div></c:otherwise>
+                                            </c:choose>
+                                            <c:choose>
+                                                <c:when test="${not empty server.JDBCPassword}"><div class="dbPass">Password: *****</div></c:when>
+                                                <c:otherwise><div class="defaultValue grayNote">Password: sonar</div></c:otherwise>
+                                            </c:choose>
+                                        </c:if>
                                     </td>
-                                    <td class="remove">
-                                        <a id="removeNewServer" href="#"
-                                           onclick="SonarPlugin.removeServer('${projectServersEntry.key.externalId}', '${server.id}'); return false">remove...</a>
-                                    </td>
-                                    <td class="edit">
-                                        <a id="editServer" href="#"
-                                           onclick="SonarPlugin.editServer({id: '${server.id}', name: '${server.name}', url: '${server.url}', login: '${server.login}',
-                                                   password: '${not empty server.login ? "*****" : ""}', JDBCUrl: '${server.JDBCUrl}', JDBCUsername: '${server.JDBCUsername}',
-                                                   JDBCPassword: '${not empty server.JDBCUsername ? "*****" : ""}', projectId: '${projectServersEntry.key.externalId}'}); return false">edit</a>
-                                    </td>
+                                    <c:if test="${userHasPermissionManagement}">
+                                        <td class="remove">
+                                            <a id="removeNewServer" href="#"
+                                            onclick="SonarPlugin.removeServer('${projectServersEntry.key.externalId}', '${server.id}'); return false">remove...</a>
+                                        </td>
+                                        <td class="edit">
+                                            <a id="editServer" href="#"
+                                            onclick="SonarPlugin.editServer({id: '${server.id}', name: '${server.name}', url: '${server.url}', login: '${server.login}',
+                                                    password: '${not empty server.login ? "*****" : ""}', JDBCUrl: '${server.JDBCUrl}', JDBCUsername: '${server.JDBCUsername}',
+                                                    JDBCPassword: '${not empty server.JDBCUsername ? "*****" : ""}', projectId: '${projectServersEntry.key.externalId}'}); return false">edit</a>
+                                        </td>
+                                    </c:if>
                                 </tr>
                             </c:forEach>
                         </c:forEach>


### PR DESCRIPTION
Proposal for [Capacity to manage (edit/remove) only by admin](https://github.com/Linfar/TeamCity.SonarQubePlugin/issues/14) *bug*.

Granted on **Permission.EDIT_PROJECT**, so give the capacity to create a dedicated role.

The best could be to create/register a new specific permission, but not sure possible with TC 8.1 (update :   [not possible](https://devnet.jetbrains.com/message/5549677;jsessionid=88C61A415D3ED86421527648A6BBC731#5549677))